### PR TITLE
Add native client for AMD64 and don't use qemu

### DIFF
--- a/rootfs/etc/services.d/pfclient/run
+++ b/rootfs/etc/services.d/pfclient/run
@@ -1,35 +1,16 @@
 #!/usr/bin/with-contenv bash
 #shellcheck shell=bash
 
-# Test pfclient can run natively (without qemu)
-if /usr/local/bin/pfclient --version > /dev/null 2>&1; then 
-  # pfclient can be run natively
-  s6-setuidgid nobody /usr/local/bin/pfclient \
-    --connection_type=1 \
-    --address="${BEASTHOST}" \
-    --port="${BEASTPORT}" \
-    --data_format=1 \
-    --sharecode="${SHARECODE}" \
-    --lat="${LAT}" \
-    --lon="${LONG}" \
-    --pid_file=/run/pfclient.pid \
-    --config_path=/config/pfclient-config.json \
-    --log_path=/var/log/pfclient \
-    2>&1 | mawk -W Interactive '{print "[pfclient_daemon] " $0}'
-
-else
-  # pfclient needs qemu
-  s6-setuidgid nobody qemu-arm-static /usr/local/bin/pfclient \
-    --connection_type=1 \
-    --address="${BEASTHOST}" \
-    --port="${BEASTPORT}" \
-    --data_format=1 \
-    --sharecode="${SHARECODE}" \
-    --lat="${LAT}" \
-    --lon="${LONG}" \
-    --pid_file=/run/pfclient.pid \
-    --config_path=/config/pfclient-config.json \
-    --log_path=/var/log/pfclient \
-    2>&1 | mawk -W Interactive '{print "[pfclient_daemon] " $0}'
-fi
-
+# pfclient can be run natively
+s6-setuidgid nobody /usr/local/bin/pfclient \
+  --connection_type=1 \
+  --address="${BEASTHOST}" \
+  --port="${BEASTPORT}" \
+  --data_format=1 \
+  --sharecode="${SHARECODE}" \
+  --lat="${LAT}" \
+  --lon="${LONG}" \
+  --pid_file=/run/pfclient.pid \
+  --config_path=/config/pfclient-config.json \
+  --log_path=/var/log/pfclient \
+  2>&1 | mawk -W Interactive '{print "[pfclient_daemon] " $0}'

--- a/rootfs/firstrun
+++ b/rootfs/firstrun
@@ -1,14 +1,5 @@
 #!/usr/bin/env bash
 #shellcheck shell=bash
 
-# Test pfclient can run natively (without qemu)
-if /usr/local/bin/pfclient --version > /dev/null 2>&1; then 
-  # pfclient can be run natively
-  s6-setuidgid nobody /usr/local/bin/pfclient
-
-else
-  # pfclient needs qemu
-  s6-setuidgid nobody qemu-arm-static /usr/local/bin/pfclient
-
-fi
-
+# pfclient can be run natively
+s6-setuidgid nobody /usr/local/bin/pfclient


### PR DESCRIPTION
Avoid qemu-static for emulate ARM archtecture is more gentle with memory
on AMD64 based computers. Avoids some memory leaks (that are yet to be
determined if present on emulator only or native armhf client binary).

Closes #21 

Signed-off-by: Josenivaldo Benito Jr <jbenito@rxnetworks.com>