### PR TITLE
Revert "Update Dockerfile with new Plane Finder clients (#115)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,14 @@ RUN set -x && \
   # Deps for pfclient
   KEPT_PACKAGES+=(ca-certificates) && \
   if [[ "${TARGETARCH}" == "arm64" ]]; then \
-  DOWNLOAD_URL="http://client.planefinder.net/pfclient_5.3.29_arm64.tar.gz"; \
-  DOWNLOAD_MD5SUM=d8b5e7cf6d6d2fbde74dc560b8666f4e; \
+  DOWNLOAD_URL="http://client.planefinder.net/pfclient_5.3.2_arm64.tar.gz"; \
+  DOWNLOAD_MD5SUM=4de73d381368307543d928387e308c11; \
   elif [[ "${TARGETARCH}" == "amd64" ]]; then \
-  DOWNLOAD_URL="http://client.planefinder.net/pfclient_5.3.29_amd64.tar.gz"; \
-  DOWNLOAD_MD5SUM=b655a6479625d6fb08763abc11fc76da; \
+  DOWNLOAD_URL="http://client.planefinder.net/pfclient_5.0.162_amd64.tar.gz"; \
+  DOWNLOAD_MD5SUM=58579fe2fef6a79b49a530163bdc5360; \
   else \
-  DOWNLOAD_URL="http://client.planefinder.net/pfclient_5.3.29_armhf.tar.gz"; \
-  DOWNLOAD_MD5SUM=0949c252cb24d423f53b0203f47d5389; \
+  DOWNLOAD_URL="http://client.planefinder.net/pfclient_5.3.2_armhf.tar.gz"; \
+  DOWNLOAD_MD5SUM=88f06625c34906f5dc9361d914be87eb; \
   fi && \
   # pfclient install & healthchecks
   KEPT_PACKAGES+=(curl) && \


### PR DESCRIPTION
This reverts commit 5a78d04fe79c8c4eb035b78182e805f14d62a232.

this leads to glibc issues
[pfclient_daemon] /usr/local/bin/pfclient:
/lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by /usr/local/bin/pfclient)

revert for now will test local builds